### PR TITLE
Add support for activating JMX beans

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <javadoc.plugin.version>2.10.4</javadoc.plugin.version>
         <source.plugin.version>3.0.1</source.plugin.version>
+        <!-- Keep up-to-date with dropwizard-bom -->
+        <jetty.version>9.3.9.v20160517</jetty.version>
     </properties>
 
     <dependencyManagement>
@@ -66,6 +68,12 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-jmx</artifactId>
+            <version>${jetty.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/zone/dragon/dropwizard/ClassAnnotationActivator.java
+++ b/src/main/java/zone/dragon/dropwizard/ClassAnnotationActivator.java
@@ -1,0 +1,85 @@
+package zone.dragon.dropwizard;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.glassfish.hk2.api.ActiveDescriptor;
+import org.glassfish.hk2.api.Filter;
+import org.glassfish.hk2.api.InstanceLifecycleEvent;
+import org.glassfish.hk2.api.InstanceLifecycleEventType;
+import org.glassfish.hk2.api.InstanceLifecycleListener;
+
+import javax.inject.Singleton;
+import java.lang.annotation.Annotation;
+
+/**
+ * {@link InstanceLifecycleListener} that listens for {@link Singleton singleton} services that are annotated with {@link T};
+ * The {@link #activate(ActiveDescriptor, Object, Annotation) activate} method will be invoked for the service that has the annotation
+ * after the service has been created.
+ *
+ * @param <T>
+ *     Annotation type that is used to indicate if the {@link #activate(ActiveDescriptor, Object, Annotation) activate} should be called.
+ */
+@Singleton
+@RequiredArgsConstructor
+public abstract class ClassAnnotationActivator<T extends Annotation> implements InstanceLifecycleListener {
+    private static final Filter SINGLETON_FILTER = descriptor -> Singleton.class.getName().equals(descriptor.getScope());
+    /**
+     * Annotation type that is used to indicate if the {@link #activate(ActiveDescriptor, Object, Annotation) activate} should be called.
+     */
+    @NonNull
+    private final Class<T> annotationType;
+
+    @Override
+    public Filter getFilter() {
+        return SINGLETON_FILTER;
+    }
+
+    /**
+     * When a service is created, this is called if the service is annotated with {@link T}.
+     *
+     * @param descriptor
+     *     Descriptor for the service being created
+     * @param service
+     *     Instance of the service being created
+     * @param annotation
+     *     Annotation on the service that binds it to this activator
+     */
+    protected abstract void activate(ActiveDescriptor<?> descriptor, Object service, T annotation);
+
+    /**
+     * When a service is disposed, this is called if the service is annotated with {@link T}.
+     *
+     * @param descriptor
+     *     Descriptor for the service being disposed
+     * @param service
+     *     Instance of the service being disposed
+     * @param annotation
+     *     Annotation on the service that binds it to this activator
+     */
+    protected void deactivate(ActiveDescriptor<?> descriptor, Object service, T annotation) {}
+
+    @Override
+    public void lifecycleEvent(InstanceLifecycleEvent lifecycleEvent) {
+        if (lifecycleEvent.getEventType() == InstanceLifecycleEventType.POST_PRODUCTION) {
+            Object              object     = lifecycleEvent.getLifecycleObject();
+            ActiveDescriptor<?> descriptor = lifecycleEvent.getActiveDescriptor();
+            if (object == null) {
+                return;
+            }
+            T annotation = object.getClass().getAnnotation(annotationType);
+            if (annotation != null) {
+                activate(descriptor, object, annotation);
+            }
+        } else if (lifecycleEvent.getEventType() == InstanceLifecycleEventType.PRE_DESTRUCTION) {
+            Object              object     = lifecycleEvent.getLifecycleObject();
+            ActiveDescriptor<?> descriptor = lifecycleEvent.getActiveDescriptor();
+            if (object == null) {
+                return;
+            }
+            T annotation = object.getClass().getAnnotation(annotationType);
+            if (annotation != null) {
+                deactivate(descriptor, object, annotation);
+            }
+        }
+    }
+}

--- a/src/main/java/zone/dragon/dropwizard/HK2Bundle.java
+++ b/src/main/java/zone/dragon/dropwizard/HK2Bundle.java
@@ -30,6 +30,7 @@ import org.glassfish.hk2.utilities.binding.ScopedBindingBuilder;
 import org.glassfish.hk2.utilities.binding.ServiceBindingBuilder;
 import org.glassfish.jersey.process.internal.RequestScoped;
 import zone.dragon.dropwizard.health.HealthCheckActivator;
+import zone.dragon.dropwizard.jmx.MBeanActivator;
 import zone.dragon.dropwizard.lifecycle.LifeCycleActivator;
 import zone.dragon.dropwizard.metrics.MetricActivator;
 import zone.dragon.dropwizard.task.TaskActivator;
@@ -39,6 +40,8 @@ import javax.validation.Validator;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 import java.lang.annotation.Annotation;
+
+import static org.glassfish.hk2.utilities.ServiceLocatorUtilities.addClasses;
 
 /**
  * Provides integration between DropWizard and HK2, allowing developers to leverage the framework built into Jersey.
@@ -96,7 +99,7 @@ public class HK2Bundle<T extends Configuration> implements ConfiguredBundle<T> {
     }
 
     public void autoBind(@NonNull Class<?>... serviceClasses) {
-        ServiceLocatorUtilities.addClasses(getLocator(), serviceClasses);
+        addClasses(getLocator(), serviceClasses);
     }
 
     public void autoBind(@NonNull Factory<?>... factories) {
@@ -198,6 +201,7 @@ public class HK2Bundle<T extends Configuration> implements ConfiguredBundle<T> {
         environment.jersey().register(MetricActivator.class);
         environment.jersey().register(LifeCycleActivator.class);
         environment.jersey().register(TaskActivator.class);
+        addClasses(getLocator(), true, MBeanActivator.class);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/zone/dragon/dropwizard/jmx/MBeanActivator.java
+++ b/src/main/java/zone/dragon/dropwizard/jmx/MBeanActivator.java
@@ -1,0 +1,34 @@
+package zone.dragon.dropwizard.jmx;
+
+import org.eclipse.jetty.jmx.MBeanContainer;
+import org.eclipse.jetty.util.annotation.ManagedObject;
+import org.glassfish.hk2.api.ActiveDescriptor;
+import zone.dragon.dropwizard.ClassAnnotationActivator;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.lang.management.ManagementFactory;
+
+/**
+ * Activator that automatically exposes HK2 singletons over JMX if they have the {@link ManagedObject} annotation
+ */
+@Singleton
+public class MBeanActivator extends ClassAnnotationActivator<ManagedObject> {
+    private final MBeanContainer container;
+
+    @Inject
+    public MBeanActivator() {
+        super(ManagedObject.class);
+        container = new MBeanContainer(ManagementFactory.getPlatformMBeanServer());
+    }
+
+    @Override
+    protected void activate(ActiveDescriptor<?> descriptor, Object service, ManagedObject annotation) {
+        container.beanAdded(null, service);
+    }
+
+    @Override
+    protected void deactivate(ActiveDescriptor<?> descriptor, Object service, ManagedObject annotation) {
+        container.beanRemoved(null, service);
+    }
+}

--- a/src/test/java/zone/dragon/dropwizard/jmx/MBeanActivatorTest.java
+++ b/src/test/java/zone/dragon/dropwizard/jmx/MBeanActivatorTest.java
@@ -1,0 +1,73 @@
+package zone.dragon.dropwizard.jmx;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.eclipse.jetty.util.annotation.ManagedAttribute;
+import org.eclipse.jetty.util.annotation.ManagedObject;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.glassfish.jersey.client.JerseyWebTarget;
+import org.junit.ClassRule;
+import org.junit.Test;
+import zone.dragon.dropwizard.HK2Bundle;
+
+import javax.inject.Singleton;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import java.lang.management.ManagementFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MBeanActivatorTest {
+    @ClassRule
+    public static final DropwizardAppRule<Configuration> RULE = new DropwizardAppRule<>(JmxApp.class, new Configuration());
+
+    public static class JmxApp extends Application<Configuration> {
+        @Override
+        public void initialize(Bootstrap<Configuration> bootstrap) {
+            HK2Bundle.addTo(bootstrap);
+        }
+
+        @Override
+        public void run(Configuration configuration, Environment environment) throws Exception {
+            environment.jersey().register(JmxResource.class);
+        }
+    }
+
+    @Path("/jmx")
+    @Singleton
+    @ManagedObject
+    public static class JmxResource {
+        @ManagedAttribute("Returns an attribute")
+        public int getAttribute() {
+            return 42;
+        }
+
+        @GET
+        public int getValue() {
+            return 3;
+        }
+    }
+
+    protected JerseyWebTarget client = JerseyClientBuilder.createClient().target(String.format("http://localhost:%d", RULE.getLocalPort()));
+
+    @Test
+    public void testJmxAttribute()
+    throws MalformedObjectNameException, AttributeNotFoundException, MBeanException, ReflectionException, InstanceNotFoundException {
+        MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
+        System.out.println(platformMBeanServer.getMBeanCount());
+        int result = client.path("jmx").request().get(Integer.class);
+        assertThat(platformMBeanServer.getAttribute(new ObjectName("zone.dragon.dropwizard.jmx:id=0,type=mbeanactivatortest$jmxresource"),
+                                                    "attribute"
+        )).isEqualTo(42);
+    }
+}


### PR DESCRIPTION
This enables support for auto-registering services annotated with `@ManagedObject` as JMX beans